### PR TITLE
fix links in README.md files

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ A Ruby client for the 2Captcha API.
   - [GeeTest V4](#geetest-v4)
   - [Audio](#audio)
   - [Yandex](#yandex)
-  - [CyberSiARA](#cyber_siara)
-  - [DataDome](#data-dome)
+  - [CyberSiARA](#cybersiara)
+  - [DataDome](#datadome)
   - [MTCaptcha](#mtcaptcha)
 - [Other methods](#other-methods)
-  - [send / get_result](#send--getresult)
+  - [send / get_result](#send-get_result)
   - [balance](#balance)
   - [report](#report)
   - [Error handling](#error-handling)
@@ -361,7 +361,7 @@ result = client.mt_captcha({
 
 ## Other methods
 
-### send / get_result
+<h3 id="send-get_result"> send / get_result</h3>
 These methods can be used for manual captcha submission and answer polling.
 ```ruby
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -25,11 +25,11 @@ Ruby-клиент для API 2Captcha.
   - [Lemin Cropped Captcha](#lemin-cropped-captcha)
   - [GeeTest V4](#geetest-v4)
   - [Аудио](#audio)
-  - [CyberSiARA](#cyber_siara)
-  - [DataDome](#data-dome)
+  - [CyberSiARA](#cybersiara)
+  - [DataDome](#datadome)
   - [MTCaptcha](#mtcaptcha)
 - [Другие методы](#other-methods)
-  - [send / get_result](#send--getresult)
+  - [send / get_result](#send-get_result)
   - [balance](#balance)
   - [report](#report)
   - [Обработка ошибок](#error-handling)
@@ -318,7 +318,7 @@ result = client.mt_captcha({
 
 ## Другие методы
 
-### send / get_result
+<h3 id="send-get_result"> send / get_result</h3>
 Эти методы могут быть использованы для ручного отправления капчи и получения результата.
 ```ruby
 # пример для обычной капчи


### PR DESCRIPTION
### Done:
- Fix links _CyberSiARA_ _DataDome_ _send / get_result_  in README.md files

Screenshot (wrong links):
![image](https://github.com/2captcha/2captcha-ruby/assets/38065632/ecf7376a-ae7f-447d-8bac-561a2e0c1512)
